### PR TITLE
Makes shadow_puppet exit with a proper error code.

### DIFF
--- a/lib/shadow_puppet/manifest.rb
+++ b/lib/shadow_puppet/manifest.rb
@@ -237,11 +237,11 @@ module ShadowPuppet
     def execute(force=false)
       return false if executed? && !force
       evaluate_recipes
-      apply
+      transaction = apply
     rescue Exception => e
       false
     else
-      true
+      not transaction.any_failed?
     ensure
       @executed = true
     end
@@ -253,11 +253,11 @@ module ShadowPuppet
     def execute!(force=false)
       return false if executed? && !force
       evaluate_recipes
-      apply
+      transaction = apply
     rescue Exception => e
       raise e
     else
-      true
+      not transaction.any_failed?
     ensure
       @executed = true
     end
@@ -305,8 +305,9 @@ module ShadowPuppet
     # Create a catalog of all contained Puppet Resources and apply that
     # catalog to the currently running system
     def apply
-      catalog.apply
+      transaction = catalog.apply
       catalog.clear
+      transaction
     end
 
     def resource_or_reference(type, *args)

--- a/spec/fixtures/manifests.rb
+++ b/spec/fixtures/manifests.rb
@@ -1,6 +1,22 @@
 class BlankManifest < ShadowPuppet::Manifest
 end
 
+class SuccessfulManifest < ShadowPuppet::Manifest
+  recipe :foo
+
+  def foo
+    exec('foo', :command => 'true')
+  end
+end
+
+class FailureManifest < SuccessfulManifest
+  recipe :bar
+
+  def bar
+    exec('bar', :command => 'false')
+  end
+end
+
 #this does nothing
 class NoOpManifest < ShadowPuppet::Manifest
   def foo

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -1,5 +1,29 @@
 describe "A manifest" do
 
+  describe "when successful" do
+
+    before(:each) do
+      @manifest = SuccessfulManifest.new
+    end
+
+    it "returns true when executed" do
+      @manifest.execute.should be_true
+    end
+
+  end
+
+  describe "with resouces that fail" do
+
+    before(:each) do
+      @manifest = FailureManifest.new
+    end
+
+    it "returns false when executed" do
+      @manifest.execute.should be_false
+    end
+
+  end
+
   describe "when blank" do
 
     before(:each) do


### PR DESCRIPTION
This fixes a long standing issue where shadow_puppet doesn't exit with
an error code if one of the resouces fails to apply. This will allow
deploys to rollback when there is a failure in a moonshine recipe.
