### PR TITLE
Add workaround for activesupport 4.0.0 bug.

### DIFF
--- a/lib/shadow_puppet/core_ext.rb
+++ b/lib/shadow_puppet/core_ext.rb
@@ -3,6 +3,7 @@ require 'active_support/version'
 
 # ActiveSupport 3 doesn't automatically load core_ext anymore
 if ActiveSupport::VERSION::MAJOR >= 3
+  require 'active_support/deprecation'
   require 'active_support/core_ext'
 end
 


### PR DESCRIPTION
Adds a workaround for an activesupport 4.0.0 circular reference bug
(rails bug #12876 - https://github.com/rails/rails/issues/12876).
