### PR TITLE
Fixes issue #2.

### DIFF
--- a/lib/shadow_puppet/manifest.rb
+++ b/lib/shadow_puppet/manifest.rb
@@ -112,8 +112,8 @@ module ShadowPuppet
     # calls to recipe.
     def self.recipe(*methods)
       return nil if methods.nil? || methods == [] # TODO can probably replace with if methods.blank?
-      options = methods.extract_options!
       methods.each do |meth|
+        options = methods.extract_options!
         options = configuration[meth.to_sym] if options == {} # TODO can probably be replaced with options.blank?
         options ||= {}
         recipes << [meth.to_sym, options]

--- a/spec/fixtures/manifests.rb
+++ b/spec/fixtures/manifests.rb
@@ -202,3 +202,19 @@ class DuplicateResourceTest < ShadowPuppet::Manifest
       :logoutput => true
   end
 end
+
+class MultipleRecipeConfigurationTest < ShadowPuppet::Manifest
+  configure({
+    :foo => {:man => 'chu'},
+    :bar => {:food => 'yummy'}
+  })
+  recipe :foo, :bar
+
+  def foo(options = {})
+    exec 'foo', :command => 'true'
+  end
+
+  def bar(options = {})
+    exec 'bar', :command => 'true'
+  end
+end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -321,4 +321,20 @@ describe "A manifest" do
       @manifest.execute!
     end
   end
+
+  describe "when configure is used to configure multiple recipes" do
+    before(:each) do
+      @manifest = MultipleRecipeConfigurationTest.new
+    end
+
+    it "passes the appropriate options to each recipe" do
+      @manifest.should_receive(:foo).with({'man' => 'chu'})
+      @manifest.should_receive(:bar).with({'food' => 'yummy'})
+      @manifest.send(:evaluate_recipes)
+    end
+
+    it "returns true when executed" do
+      @manifest.execute!.should be_true
+    end
+  end
 end


### PR DESCRIPTION
Calling multiple recipes sends incorrect configuration options. The
extract_options method needs to be called once for each argument to the
recipes method.
