### PR TITLE
Create a default base context.

### DIFF
--- a/lib/shadow_puppet/manifest.rb
+++ b/lib/shadow_puppet/manifest.rb
@@ -94,6 +94,7 @@ module ShadowPuppet
       Puppet[:group] = Process.gid
       Puppet::Util::Log.newdestination(:console)
       Puppet[:diff_args] = "-u"
+      Puppet.push_context(Puppet.base_context(Puppet.settings), "Update for application's settings")
 
       configure(config)
       @executed = false

--- a/lib/shadow_puppet/version.rb
+++ b/lib/shadow_puppet/version.rb
@@ -1,3 +1,3 @@
 module ShadowPuppet
-  VERSION = "0.9.0"
+  VERSION = "0.9.1.alpha1"
 end


### PR DESCRIPTION
This fixes the "no 'environments' in" error seen while deploying using Puppet 3.6.x.
